### PR TITLE
Update Sqlite with Foreign Key support

### DIFF
--- a/candig_cnv_service/api/operations.py
+++ b/candig_cnv_service/api/operations.py
@@ -44,7 +44,7 @@ def _report_object_exists(typename, **kwargs):
     """
     report = typename + ' already exists'
     logger().warning(struct_log(action=report, **kwargs))
-    return dict(message=report, code=405)
+    return dict(message=report, code=400)
 
 
 def _report_foreign_key(typename, **kwargs):
@@ -57,7 +57,7 @@ def _report_foreign_key(typename, **kwargs):
     """
     report = typename + ' requires an existing foreign key'
     logger().warning(struct_log(action=report, **kwargs))
-    return dict(message=report, code=405)
+    return dict(message=report, code=400)
 
 
 def _report_update_failed(typename, exception, **kwargs):
@@ -168,7 +168,7 @@ def add_patients(body):
     except exc.IntegrityError:
         db_session.rollback()
         err = _report_object_exists('patient: ' + body['patient_id'], **body)
-        return err, 405
+        return err, 400
     except ORMException as e:
         db_session.rollback()
         err = _report_write_error('patient', e, **body)
@@ -220,16 +220,14 @@ def add_samples(body):
         db_session.add(orm_sample)
         db_session.commit()
     except exc.IntegrityError as ie:
-        # TODO: Error for foreign key constraints
-
         if (ie.args[0].find("FOREIGN KEY constraint failed")):
             db_session.rollback()
             err = _report_foreign_key('sample: ' + body['sample_id'], **body)
-            return err, 405
+            return err, 400
 
         db_session.rollback()
         err = _report_object_exists('sample: ' + body['sample_id'], **body)
-        return err, 405
+        return err, 400
     except ORMException as e:
         db_session.rollback()
         err = _report_write_error('sample', e, **body)

--- a/candig_cnv_service/api/operations.py
+++ b/candig_cnv_service/api/operations.py
@@ -182,6 +182,14 @@ def add_samples(body):
 
     db_session = get_session()
 
+    print(body)
+
+    if not body.get('patient_id'):
+        err = dict(
+            message="No patient_id provided",
+            code=400)
+        return err, 400
+
     if not body.get('sample_id'):
         err = dict(
             message="No sample_id provided",
@@ -189,7 +197,8 @@ def add_samples(body):
         return err, 400
 
     try:
-        orm_sample = Sample(sample_id=body['sample_id'])
+        orm_sample = Sample(sample_id=body['sample_id'],
+                            patient_id=body['patient_id'])
     except TypeError as e:
         err = _report_conversion_error('sample', e, **body)
         return err, 400
@@ -198,6 +207,7 @@ def add_samples(body):
         db_session.add(orm_sample)
         db_session.commit()
     except exc.IntegrityError:
+        # TODO: Error for foreign key constraints
         db_session.rollback()
         err = _report_object_exists('sample: ' + body['sample_id'], **body)
         return err, 405
@@ -210,7 +220,35 @@ def add_samples(body):
 
 
 def add_segments(body):
-    return [], 200
+    """
+    Creates a new CNV following the CNV schema attached to an
+    existing sample.
+
+    :param body: POST request body
+    :type body: object
+
+    :returns: message, 201 on success, error code on failure
+    :rtype: object, int
+
+    .. note::
+        Refer to the OpenAPI Spec for a proper schemas of CNV objects.
+    """
+
+    # db_session = get_session()
+
+    if not body.get('patient_id'):
+        err = dict(
+            message="No patient_id provided",
+            code=400)
+        return err, 400
+
+    if not body.get('sample_id'):
+        err = dict(
+            message="No sample_id provided",
+            code=400)
+        return err, 400
+
+    return {"code": 201, "message": ""}, 201
 
 
 def validate_uuid_string(field_name, uuid_str):

--- a/candig_cnv_service/orm/__init__.py
+++ b/candig_cnv_service/orm/__init__.py
@@ -50,6 +50,8 @@ def add_engine_pidguard(engine):
                 % (connection_record.info["pid"], pid)
             )
 
+    # From https://stackoverflow.com/questions/2614984/
+    # sqlite-sqlalchemy-how-to-enforce-foreign-keys
     @event.listens_for(engine, "connect")
     def _set_sqlite_pragma(
         _dbapi_connection, connection_record

--- a/candig_cnv_service/orm/__init__.py
+++ b/candig_cnv_service/orm/__init__.py
@@ -5,6 +5,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 from tornado.options import options
+from sqlite3 import Connection as SQLite3Connection
 
 ORMException = SQLAlchemyError
 
@@ -48,6 +49,15 @@ def add_engine_pidguard(engine):
                 "attempting to check out in pid %s"
                 % (connection_record.info["pid"], pid)
             )
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(
+        _dbapi_connection, connection_record
+    ):  # pylint:disable=unused-variable
+        if isinstance(_dbapi_connection, SQLite3Connection):
+            cursor = _dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON;")
+            cursor.close()
 
 
 def init_db(uri=None):

--- a/candig_cnv_service/orm/models.py
+++ b/candig_cnv_service/orm/models.py
@@ -1,11 +1,38 @@
+"""
+SQLAlchemy models for database
+"""
+
+import json
+
 from sqlalchemy import Column, String, Integer, ForeignKey, Float
+from sqlalchemy import TypeDecorator
 from sqlalchemy.orm import relationship
 
 from candig_cnv_service.orm import Base
 from candig_cnv_service.orm.guid import GUID
 
 
+class JsonArray(TypeDecorator):
+    """
+    Custom array type to emulate arrays in sqlite3
+    """
+
+    impl = String
+
+    def process_bind_param(self, value, dialect):
+        return json.dumps(value)
+
+    def process_result_value(self, value, dialect):
+        return json.loads(value)
+
+    def copy(self):
+        return JsonArray(self.impl.length)
+
+
 class Patient(Base):
+    """
+    SQLAlchemy class representing a Patient
+    """
     __tablename__ = "patient"
 
     patient_id = Column(GUID(), primary_key=True)
@@ -13,14 +40,23 @@ class Patient(Base):
 
 
 class Sample(Base):
+    """
+    SQLAlchemy class representing a Sample tied to a Patient
+    """
     __tablename__ = "sample"
 
     sample_id = Column(String(100), primary_key=True)
-    patient_id = Column(GUID(), ForeignKey("patient.patient_id"))
+    patient_id = Column(GUID(),
+                        ForeignKey("patient.patient_id"),
+                        nullable=False)
     cnv_id = relationship("CNV")
 
 
 class CNV(Base):
+    """
+    SQLAlchemy class representing a collection of Copy Number
+    Variants, all tied to a Sample
+    """
     __tablename__ = "cnv"
     cnv_id = Column(Integer, primary_key=True)
     sample_id = Column(String(100), ForeignKey("sample.sample_id"))


### PR DESCRIPTION
This PR does not add CNV creation, rather it fixes an issue with Sqlite3 where foreign keys were not enforced by default. This required a hook to be added in the database set up to trigger the command. Additional error checking was added to report FK errors, and error codes were all changed to 400 for the time being to reflect the current spec. 