### PR TITLE
Add add_patients

### DIFF
--- a/candig_cnv_service/api/cnv_def.yaml
+++ b/candig_cnv_service/api/cnv_def.yaml
@@ -310,12 +310,10 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
                   $ref: '#/components/schemas/Success'
-                example:
-                  code: 201
-                  message: CNV successfully added
+              example:
+                code: 201
+                message: CNV successfully added
                   
         '400':
           description: Input provided in body does not pass schema validation

--- a/candig_cnv_service/api/operations.py
+++ b/candig_cnv_service/api/operations.py
@@ -8,7 +8,7 @@ import uuid
 from sqlalchemy import exc
 
 from candig_cnv_service.orm import get_session, ORMException
-from candig_cnv_service.orm.models import Patient, Sample
+from candig_cnv_service.orm.models import Patient, Sample, CNV
 from candig_cnv_service import orm
 from candig_cnv_service.api.logging import apilog, logger
 from candig_cnv_service.api.logging import structured_log as struct_log
@@ -251,7 +251,7 @@ def add_segments(body):
         Refer to the OpenAPI Spec for a proper schemas of CNV objects.
     """
 
-    # db_session = get_session()
+    db_session = get_session()
 
     if not body.get('patient_id'):
         err = dict(
@@ -265,7 +265,38 @@ def add_segments(body):
             code=400)
         return err, 400
 
-    return {"code": 201, "message": ""}, 201
+    segments = body["segments"]
+    # TODO Deal with duplicates/better PK implementation
+    for segment in segments:
+        segment["sample_id"] = body["sample_id"]
+
+        print(segment)
+        try:
+            orm_segment = CNV(**segment)
+        except TypeError as e:
+            err = _report_conversion_error('segment', e, **body)
+            return err, 400
+
+        try:
+            db_session.add(orm_segment)
+            db_session.commit()
+        except exc.IntegrityError as ie:
+            if (ie.args[0].find("FOREIGN KEY constraint failed")):
+                db_session.rollback()
+                err = _report_foreign_key('segment: ' + body['sample_id'],
+                                          **body)
+                return err, 400
+
+            db_session.rollback()
+            err = _report_object_exists('segment: ' + body['sample_id'],
+                                        **body)
+            return err, 400
+        except ORMException as e:
+            db_session.rollback()
+            err = _report_write_error('segment', e, **body)
+            return err, 500
+
+    return {"code": 201, "message": "Segments successfully added"}, 201
 
 
 def validate_uuid_string(field_name, uuid_str):

--- a/candig_cnv_service/api/operations.py
+++ b/candig_cnv_service/api/operations.py
@@ -125,8 +125,7 @@ def get_patients():
     except orm.ORMException as e:
         err = _report_search_failed("patient", e, patient_id="all")
         return err, 500
-    print(q)
- 
+
     patient_ids_dict = [orm.dump(p) for p in q]
     return [d["patient_id"] for d in patient_ids_dict], 200
 
@@ -252,7 +251,6 @@ def add_segments(body):
         Refer to the OpenAPI Spec for a proper schemas of CNV objects.
     """
 
-
     db_session = get_session()
 
     if not body.get('patient_id'):
@@ -268,7 +266,6 @@ def add_segments(body):
         return err, 400
 
     segments = body["segments"]
-    # TODO Deal with duplicates/better PK implementation
     for segment in segments:
         segment["sample_id"] = body["sample_id"]
 

--- a/candig_cnv_service/api/operations.py
+++ b/candig_cnv_service/api/operations.py
@@ -44,7 +44,7 @@ def _report_object_exists(typename, **kwargs):
     """
     report = typename + ' already exists'
     logger().warning(struct_log(action=report, **kwargs))
-    return dict(message=report, code=405)
+    return dict(message=report, code=400)
 
 
 def _report_foreign_key(typename, **kwargs):
@@ -57,7 +57,7 @@ def _report_foreign_key(typename, **kwargs):
     """
     report = typename + ' requires an existing foreign key'
     logger().warning(struct_log(action=report, **kwargs))
-    return dict(message=report, code=405)
+    return dict(message=report, code=400)
 
 
 def _report_update_failed(typename, exception, **kwargs):
@@ -168,7 +168,7 @@ def add_patients(body):
     except exc.IntegrityError:
         db_session.rollback()
         err = _report_object_exists('patient: ' + body['patient_id'], **body)
-        return err, 405
+        return err, 400
     except ORMException as e:
         db_session.rollback()
         err = _report_write_error('patient', e, **body)
@@ -220,16 +220,14 @@ def add_samples(body):
         db_session.add(orm_sample)
         db_session.commit()
     except exc.IntegrityError as ie:
-        # TODO: Error for foreign key constraints
-
         if (ie.args[0].find("FOREIGN KEY constraint failed")):
             db_session.rollback()
             err = _report_foreign_key('sample: ' + body['sample_id'], **body)
-            return err, 405
+            return err, 400
 
         db_session.rollback()
         err = _report_object_exists('sample: ' + body['sample_id'], **body)
-        return err, 405
+        return err, 400
     except ORMException as e:
         db_session.rollback()
         err = _report_write_error('sample', e, **body)

--- a/candig_cnv_service/api/operations.py
+++ b/candig_cnv_service/api/operations.py
@@ -182,6 +182,14 @@ def add_samples(body):
 
     db_session = get_session()
 
+    print(body)
+
+    if not body.get('patient_id'):
+        err = dict(
+            message="No patient_id provided",
+            code=400)
+        return err, 400
+
     if not body.get('sample_id'):
         err = dict(
             message="No sample_id provided",
@@ -189,7 +197,8 @@ def add_samples(body):
         return err, 400
 
     try:
-        orm_sample = Sample(sample_id=body['sample_id'])
+        orm_sample = Sample(sample_id=body['sample_id'],
+                            patient_id=body['patient_id'])
     except TypeError as e:
         err = _report_conversion_error('sample', e, **body)
         return err, 400
@@ -198,6 +207,7 @@ def add_samples(body):
         db_session.add(orm_sample)
         db_session.commit()
     except exc.IntegrityError:
+        # TODO: Error for foreign key constraints
         db_session.rollback()
         err = _report_object_exists('sample: ' + body['sample_id'], **body)
         return err, 405
@@ -210,7 +220,35 @@ def add_samples(body):
 
 
 def add_segments(body):
-    return [], 200
+    """
+    Creates a new CNV following the CNV schema attached to an
+    existing sample.
+
+    :param body: POST request body
+    :type body: object
+
+    :returns: message, 201 on success, error code on failure
+    :rtype: object, int
+
+    .. note::
+        Refer to the OpenAPI Spec for a proper schemas of CNV objects.
+    """
+
+    # db_session = get_session()
+
+    if not body.get('patient_id'):
+        err = dict(
+            message="No patient_id provided",
+            code=400)
+        return err, 400
+
+    if not body.get('sample_id'):
+        err = dict(
+            message="No sample_id provided",
+            code=400)
+        return err, 400
+
+    return {"code": 201, "message": ""}, 201
 
 
 def validate_uuid_string(field_name, uuid_str):

--- a/candig_cnv_service/orm/__init__.py
+++ b/candig_cnv_service/orm/__init__.py
@@ -50,6 +50,8 @@ def add_engine_pidguard(engine):
                 % (connection_record.info["pid"], pid)
             )
 
+    # From https://stackoverflow.com/questions/2614984/
+    # sqlite-sqlalchemy-how-to-enforce-foreign-keys
     @event.listens_for(engine, "connect")
     def _set_sqlite_pragma(
         _dbapi_connection, connection_record

--- a/candig_cnv_service/orm/__init__.py
+++ b/candig_cnv_service/orm/__init__.py
@@ -5,6 +5,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 from tornado.options import options
+from sqlite3 import Connection as SQLite3Connection
 
 ORMException = SQLAlchemyError
 
@@ -48,6 +49,15 @@ def add_engine_pidguard(engine):
                 "attempting to check out in pid %s"
                 % (connection_record.info["pid"], pid)
             )
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(
+        _dbapi_connection, connection_record
+    ):  # pylint:disable=unused-variable
+        if isinstance(_dbapi_connection, SQLite3Connection):
+            cursor = _dbapi_connection.cursor()
+            cursor.execute("PRAGMA foreign_keys=ON;")
+            cursor.close()
 
 
 def init_db(uri=None):

--- a/candig_cnv_service/orm/models.py
+++ b/candig_cnv_service/orm/models.py
@@ -58,9 +58,11 @@ class CNV(Base):
     Variants, all tied to a Sample
     """
     __tablename__ = "cnv"
-    cnv_id = Column(Integer, primary_key=True)
-    sample_id = Column(String(100), ForeignKey("sample.sample_id"))
-    start_position = Column(Integer)
+    # cnv_id = Column(Integer, primary_key=True)
+    sample_id = Column(String(100), 
+                       ForeignKey("sample.sample_id"),
+                       primary_key=True)
+    start_position = Column(Integer, primary_key=True)
     end_position = Column(Integer)
     copy_number = Column(Float)
     copy_number_ploidy_corrected = Column(Integer)

--- a/candig_cnv_service/orm/models.py
+++ b/candig_cnv_service/orm/models.py
@@ -59,7 +59,7 @@ class CNV(Base):
     """
     __tablename__ = "cnv"
     # cnv_id = Column(Integer, primary_key=True)
-    sample_id = Column(String(100), 
+    sample_id = Column(String(100),
                        ForeignKey("sample.sample_id"),
                        primary_key=True)
     start_position = Column(Integer, primary_key=True)

--- a/candig_cnv_service/orm/models.py
+++ b/candig_cnv_service/orm/models.py
@@ -63,5 +63,5 @@ class CNV(Base):
     start_position = Column(Integer)
     end_position = Column(Integer)
     copy_number = Column(Float)
-    copy_number_ploidy_correcte = Column(Integer)
+    copy_number_ploidy_corrected = Column(Integer)
     chromosome_number = Column(String(100))

--- a/candig_cnv_service/orm/models.py
+++ b/candig_cnv_service/orm/models.py
@@ -1,11 +1,38 @@
+"""
+SQLAlchemy models for database
+"""
+
+import json
+
 from sqlalchemy import Column, String, Integer, ForeignKey, Float
+from sqlalchemy import TypeDecorator
 from sqlalchemy.orm import relationship
 
 from candig_cnv_service.orm import Base
 from candig_cnv_service.orm.guid import GUID
 
 
+class JsonArray(TypeDecorator):
+    """
+    Custom array type to emulate arrays in sqlite3
+    """
+
+    impl = String
+
+    def process_bind_param(self, value, dialect):
+        return json.dumps(value)
+
+    def process_result_value(self, value, dialect):
+        return json.loads(value)
+
+    def copy(self):
+        return JsonArray(self.impl.length)
+
+
 class Patient(Base):
+    """
+    SQLAlchemy class representing a Patient
+    """
     __tablename__ = "patient"
 
     patient_id = Column(GUID(), primary_key=True)
@@ -13,14 +40,23 @@ class Patient(Base):
 
 
 class Sample(Base):
+    """
+    SQLAlchemy class representing a Sample tied to a Patient
+    """
     __tablename__ = "sample"
 
     sample_id = Column(String(100), primary_key=True)
-    patient_id = Column(GUID(), ForeignKey("patient.patient_id"))
+    patient_id = Column(GUID(),
+                        ForeignKey("patient.patient_id"),
+                        nullable=False)
     cnv_id = relationship("CNV")
 
 
 class CNV(Base):
+    """
+    SQLAlchemy class representing a collection of Copy Number
+    Variants, all tied to a Sample
+    """
     __tablename__ = "cnv"
     cnv_id = Column(Integer, primary_key=True)
     sample_id = Column(String(100), ForeignKey("sample.sample_id"))

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -125,7 +125,7 @@ def test_add_sample_twice(test_client):
 
 def test_add_sample_no_patient(test_client):
     """
-    Test adding sample where no patient information 
+    Test adding sample where no patient information
     is present on patient table 
     """
 


### PR DESCRIPTION
This PR adds a basic implementation of the add_patients function, supporting the /patients/samples/cnv route. It will likely just be used for development and a CLI ingest will be implemented for a more robust way to ingest entire CNV files.