### PR TITLE
Add Tools to RTD

### DIFF
--- a/candig_cnv_service/tools/cnv_ingest.py
+++ b/candig_cnv_service/tools/cnv_ingest.py
@@ -10,8 +10,9 @@ from candig_cnv_service.api.exceptions import FileTypeError
 
 def main(args=None):
     """
-    Main script for ingesting CNV files through the CLI. Call this script along with
-    all the arguments needed. patient, sample and file are all required.
+    Main script for ingesting CNV files through the CLI. Call this script
+    along with all the arguments needed. patient, sample and file are all
+    required.
     """
     if args is None:
         args = sys.argv[1:]

--- a/candig_cnv_service/tools/cnv_ingest.py
+++ b/candig_cnv_service/tools/cnv_ingest.py
@@ -9,6 +9,10 @@ from candig_cnv_service.api.exceptions import FileTypeError
 
 
 def main(args=None):
+    """
+    Main script for ingesting CNV files through the CLI. Call this script along with
+    all the arguments needed. patient, sample and file are all required.
+    """
     if args is None:
         args = sys.argv[1:]
 

--- a/candig_cnv_service/tools/ingester.py
+++ b/candig_cnv_service/tools/ingester.py
@@ -26,8 +26,8 @@ class Ingester:
     :type patient: UUID
     :param sample: Sample ID that the CNV file belongs to
     :type sample: str
-    :param cnv_file: Query string or data needed by endpoint specified in endpoint_path
-    :type cnv_file: object, {param0=value0, paramN=valueN} for GET, JSON struct dependent on service endpoint for POST
+    :param cnv_file: Location of the CNV file to ingest
+    :type cnv_file: str
     """
     def __init__(self, database, patient, sample, cnv_file):
         """Constructor method
@@ -71,8 +71,8 @@ class Ingester:
 
     def db_setup(self):
         """
-        Connects to the database given using SQLAlchemy Core and 
-        attempts to query the Sample ID provided. Returns the 
+        Connects to the database given using SQLAlchemy Core and
+        attempts to query the Sample ID provided. Returns the
         engine if successful or an error if the Sample cannot
         be located.
 
@@ -153,7 +153,7 @@ class Ingester:
         manner rather than a single upload. This allows
         for a partial ingest as well as error checking
         for each row.
-        
+
         Should only be called if an integrity error
         in upload() is encountered and --sequential is
         set to true

--- a/candig_cnv_service/tools/ingester.py
+++ b/candig_cnv_service/tools/ingester.py
@@ -17,7 +17,21 @@ from candig_cnv_service.orm.models import CNV  # noqa: E402
 
 
 class Ingester:
+    """
+    This is a collection of methods to facilitate ingesting entire CNV files
+
+    :param database: Location of the database to ingest the CNV file
+    :type database: str
+    :param patient: Patient ID that the CNV file belongs to
+    :type patient: UUID
+    :param sample: Sample ID that the CNV file belongs to
+    :type sample: str
+    :param cnv_file: Query string or data needed by endpoint specified in endpoint_path
+    :type cnv_file: object, {param0=value0, paramN=valueN} for GET, JSON struct dependent on service endpoint for POST
+    """
     def __init__(self, database, patient, sample, cnv_file):
+        """Constructor method
+        """
         self.db = "sqlite:///" + database
         self.patient = patient.replace("-", "")
         self.sample = sample
@@ -38,6 +52,14 @@ class Ingester:
         }
 
     def get_type(self):
+        """
+        Searches the given cnv_file and returns the type if valid (csv or tsv)
+
+        :raises: FileTypeError
+        :return: csv or tsv
+        :rtype: str
+
+        """
         if (self.cnv_file.find(".csv") != -1):
             return "csv"
         elif (self.cnv_file.find(".tsv") != -1):
@@ -48,6 +70,16 @@ class Ingester:
         raise FileTypeError(self.cnv_file)
 
     def db_setup(self):
+        """
+        Connects to the database given using SQLAlchemy Core and 
+        attempts to query the Sample ID provided. Returns the 
+        engine if successful or an error if the Sample cannot
+        be located.
+
+        :raises: KeyExistenceError
+        :return: engine object
+        :rtype: `~sqlalchemy.engine.Engine`
+        """
         init_db(self.db)
         engine = get_engine()
         with engine.connect() as connection:
@@ -59,7 +91,15 @@ class Ingester:
         return engine
 
     def ingest_tsv(self):
+        """
+        Ingests the provided CNV file as a .tsv and
+        appends each row to be uploaded. If the file
+        does not have the headers contained in self.headers,
+        a HeaderError will be raised.
 
+        :raises: HeaderError
+        :return: None
+        """
         with open(self.cnv_file) as cnv:
             header = cnv.readline()
             stripped = header.strip("\n").split("\t")
@@ -72,7 +112,15 @@ class Ingester:
                 self.segments.append(segment)
 
     def ingest_csv(self):
+        """
+        Ingests the provided CNV file as a .csv and
+        appends each row to be uploaded. If the file
+        does not have the headers contained in self.headers,
+        a HeaderError will be raised.
 
+        :raises: HeaderError
+        :return: None
+        """
         with open(self.cnv_file) as cnv:
             header = cnv.readline()
             stripped = header.strip("\n").split(",")
@@ -85,6 +133,13 @@ class Ingester:
                 self.segments.append(segment)
 
     def upload(self):
+        """
+        Uploads the collected CNV data using SQLAlchemy Core
+        functions to mass ingest the data.
+
+        :raises: IntegrityError
+        :return
+        """
         self.ingests[self.file_type]()
         with self.engine.connect() as connection:
             connection.execute(
@@ -94,6 +149,11 @@ class Ingester:
 
     def upload_sequential(self):
         """
+        Attempts to upload the CNV data in a sequential
+        manner rather than a single upload. This allows
+        for a partial ingest as well as error checking
+        for each row.
+        
         Should only be called if an integrity error
         in upload() is encountered and --sequential is
         set to true

--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -1,0 +1,45 @@
+Tools
+=====
+
+The tools module currently provides a CLI ingest script to add entire CNV files to the service.
+This ingest is divided between an ``Ingester`` Class located in ``ingester.py``, which provides
+database methods and file type checking and the ``cnv_ingest.py`` script which controls how the
+file is ingested.
+
+The Ingester class currently accepts CSV and TSV formatted CNV files. These files should contain
+the following headers otherwise they will not be accepted:
+
+================= ============== ============ =========== ============================
+chromosome_number start_position end_position copy_number copy_number_ploidy_corrected
+================= ============== ============ =========== ============================
+
+Other than header validation, the ingester **does not** check the contents of the file
+at this time. It is up to the uploader to insure that the data is valid.
+
+
+Ingest Usage
+============
+
+The ``cnv_ingest`` script takes a number of parameters in addition to the CNV file itself.
+
+================  ============
+Argument          Explanation
+----------------  ------------
+``patient``       Patient UUID.
+``sample``        Sample UUID.
+``file``          Location of the CNV file.
+``--database``    Location of the database (uses service default if not provided).
+``--sequential``  Boolean. If set to True, uploads the CNV sequentially if PK errors 
+                  are encountered during the bulk ingest. This will allow for a partial 
+                  upload of the CNV along with details of which segments are causing errors.
+================  ============
+
+The first three arguments need to be provided in the order shown above, with the last two 
+being optional.
+
+Example:
+
+.. code-block:: bash
+
+    python candig_cnv_service/tools/cnv_ingest.py e9200a68-1233-40d3-983f-4370b7d17ca8 8bc4d487-6163-46b7-b406-d6a308fec95e  /home/dashaylan/Documents/GSC/cnv_service/cnv_1.csv --sequential True
+


### PR DESCRIPTION
This PR extends the RTD features to include a write up about the Tools module and ingesting via the command line.

Both ingester.py and cnv_ingest.py are included and commented. 