### PR TITLE
Fixed api definition location error

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include candig_cnv_service/api/api_definition.yaml
+include README.md

--- a/candig_cnv_service/__main__.py
+++ b/candig_cnv_service/__main__.py
@@ -64,7 +64,8 @@ def configure_app():
     app = connexion.FlaskApp(
         __name__, server="tornado", options={"swagger_url": "/"}
     )
-    api_def = pkg_resources.resource_filename("candig_cnv_service", "api/api_definition.yaml") 
+    api_def = pkg_resources.resource_filename("candig_cnv_service",
+                                              "api/api_definition.yaml")
 
     app.add_api(api_def, strict_validation=True, validate_responses=True)
 

--- a/candig_cnv_service/__main__.py
+++ b/candig_cnv_service/__main__.py
@@ -3,6 +3,7 @@ import os
 import json
 import argparse
 import logging
+import pkg_resources
 
 import connexion
 
@@ -63,7 +64,7 @@ def configure_app():
     app = connexion.FlaskApp(
         __name__, server="tornado", options={"swagger_url": "/"}
     )
-    api_def = "./api/api_definition.yaml"
+    api_def = pkg_resources.resource_filename("candig_cnv_service", "api/api_definition.yaml") 
 
     app.add_api(api_def, strict_validation=True, validate_responses=True)
 

--- a/candig_cnv_service/__main__.py
+++ b/candig_cnv_service/__main__.py
@@ -41,7 +41,7 @@ def main(args=None):
     app.app.logger.setLevel(numeric_loglevel)
 
     app.app.config["name"] = args.name
-    app.app.config["self"] = "http://{}/{}".format(args.host, args.port)
+    app.app.config["self"] = "http://{}:{}".format(args.host, args.port)
     if not os.path.exists(args.database):
         os.mkdir(os.getcwd() + "/data")
     define("dbfile", default=args.database)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setuptools.setup(
     url="https://github.com/CanDIG/candig_cnv_service",
     packages=setuptools.find_packages(),
     data_files=data_files,
+    include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ with open("requirements.txt") as requirements:
         version_pin = line.split()[0]
         install_requires.append(version_pin)
 
+data_files = [("api", ["candig_cnv_service/api/api_definition.yaml"])]
+
 setuptools.setup(
     name="candig-cnv-service", # Replace with your own username
     version="0.0.1",
@@ -27,6 +29,7 @@ setuptools.setup(
     test_suite='tests',
     url="https://github.com/CanDIG/candig_cnv_service",
     packages=setuptools.find_packages(),
+    data_files=data_files,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",


### PR DESCRIPTION
This PR fixes an error occurring when installing directly from Github (listed below), where it could not find the API definition file.

```
FileNotFoundError: [Errno 2] No such file or directory: '/home/fcoralsasso/Documents/venvs/cnv_venv/lib/python3.6/site-packages/candig_cnv_service/api/api_definition.yaml'
```

The bug was fixed using `pkg_resources` module on setup.